### PR TITLE
Check for SALT length

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -7,4 +7,6 @@ DATABASE_URL="database.sqlite"
 DB_MIN_IDLE="1"
 SERVER_PORT="9090"
 WORKER_COUNT="2"
+
+# Salt must be at least 8 characters long
 SALT="salt_password"

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -30,6 +30,13 @@ pub fn create_user(conn: &mut DBPooledConnection) -> Result<(), Box<dyn Error>> 
     let password = read_password()?;
 
     let salt = env::var("SALT")?;
+    if salt.is_empty() {
+        return Err("SALT environment variable is not set or is empty".into());
+    }
+    if salt.len() < 8 {
+        return Err("SALT must be at least 8 characters long".into());
+    }
+
     let config = Config::default();
     let hashed_password =
         argon2::hash_encoded(password.as_bytes(), salt.as_bytes(), &config).unwrap();


### PR DESCRIPTION
This PR catches a potential issue when using a `SALT` value with length less than `8`.

From `argon2`'s [documentation](https://docs.rs/rust-argon2/latest/argon2/enum.Error.html), 8 is the minimum length for a salt value.

As of now, the invite code manager just panics with this error:

<img width="555" height="132" alt="Screenshot 2025-10-17 at 11 47 28 PM" src="https://github.com/user-attachments/assets/2a86ad3f-8f77-4c29-a57a-b017197e325b" />

This change handles it gracefully with a more helpful error message:

<img width="767" height="110" alt="Screenshot 2025-10-17 at 11 48 02 PM" src="https://github.com/user-attachments/assets/f384b127-ac4a-4fd3-81ef-c5e5e967e8a9" />
